### PR TITLE
Added tests for CentOS clients

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,8 @@ platforms:
             reverse-zones:
               - 0.22.172.in-addr.arpa.
   - name: ubuntu-14.04
+  - name: centos-6
+  - name: centos-7
 
 
 suites:
@@ -32,7 +34,10 @@ suites:
       - recipe[apt]
       - recipe[ipa::bootstrap]
       - recipe[test-helpers::resolvconf-fixup]
-    excludes: ubuntu-14.04
+    excludes:
+      - ubuntu-14.04
+      - centos-6
+      - centos-7
 
   - name: replica
     driver:
@@ -47,7 +52,10 @@ suites:
       - recipe[test-helpers::ip-attribute-fixup]
       - recipe[apt]
       - recipe[ipa::replica]
-    excludes: ubuntu-14.04
+    excludes:
+      - ubuntu-14.04
+      - centos-6
+      - centos-7
 
   - name: client-14
     driver:
@@ -63,7 +71,10 @@ suites:
       - recipe[apt]
       - recipe[ipa]
       - recipe[test-helpers::request-test-certs]
-    excludes: ubuntu-16.04
+    excludes:
+      - ubuntu-16.04
+      - centos-6
+      - centos-7
 
   - name: client-16
     driver:
@@ -79,4 +90,44 @@ suites:
       - recipe[apt]
       - recipe[ipa]
       - recipe[test-helpers::request-test-certs]
-    excludes: ubuntu-14.04
+    excludes:
+     - ubuntu-14.04
+     - centos-6
+     - centos-7
+
+  - name: client-el6
+    driver:
+      vm_hostname: client-el6.ipa.example.com
+      network:
+        - ['private_network', {ip: '172.22.0.17'}]
+      customize:
+        memory: 256
+    run_list:
+      - recipe[test-helpers::resolvconf-fixup]
+      - recipe[test-helpers::hostsfile-fixup]
+      - recipe[test-helpers::ip-attribute-fixup]
+      - recipe[ipa]
+      - recipe[test-helpers::request-test-certs]
+    excludes:
+      - ubuntu-14.04
+      - ubuntu-16.04
+      - centos-7
+
+  - name: client-el7
+    driver:
+      vm_hostname: client-el7.ipa.example.com
+      network:
+        - ['private_network', {ip: '172.22.0.18'}]
+      customize:
+        memory: 256
+    run_list:
+      - recipe[test-helpers::resolvconf-fixup]
+      - recipe[test-helpers::hostsfile-fixup]
+      - recipe[test-helpers::ip-attribute-fixup]
+      - recipe[ipa]
+      - recipe[test-helpers::request-test-certs]
+    excludes:
+      - ubuntu-14.04
+      - ubuntu-16.04
+      - centos-6
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This cookbook provides custom resources and recipes to install and configure
 
 * Ubuntu 14.04 - Client Only
 * Ubuntu 16.04 - Client or Replica
+* CentOS 6  - Client Only
+* CentOS 7 - Client Only
+
 
 ### Chef
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'jrb@helpscout.com'
 license           'Apache-2.0'
 description       'A cookbook for managing IPA installations.'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.2.3'
+version           '1.2.4'
 
 issues_url        'https://github.com/helpscout/chef-ipa/issues'
 source_url        'https://github.com/helpscout/chef-ipa'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ issues_url        'https://github.com/helpscout/chef-ipa/issues'
 source_url        'https://github.com/helpscout/chef-ipa'
 
 supports          'ubuntu', '>= 14.04'
+supports          'redhat', '>= 6'
 chef_version      '>= 12.6'
 
 # vim: ai ts=2 sts=2 et sw=2 ft=ruby

--- a/test/fixtures/cookbooks/test-helpers/recipes/request-test-certs.rb
+++ b/test/fixtures/cookbooks/test-helpers/recipes/request-test-certs.rb
@@ -2,7 +2,12 @@
 # Cookbook Name:: request-test-certs
 # Recipe:: hostsfile-fixup
 #
-
+case node['platform_family']
+  when 'debian'
+    key_group = 'nogroup'
+  when 'rhel'
+    key_group = 'nobody'
+end
 ipa_certificate 'testcert-simple' do
   pem_key  '/tmp/testcert-simple.key'
   pem_cert '/tmp/testcert-simple.crt'
@@ -18,10 +23,10 @@ end
 ipa_certificate 'testcert-owner-test' do
   pem_key  '/tmp/testcert-owner-test.key'
   pem_key_owner 'nobody'
-  pem_key_group 'nogroup'
+  pem_key_group key_group
   pem_key_mode  '0707'
   pem_cert '/tmp/testcert-owner-test.crt'
   pem_cert_owner 'nobody'
-  pem_cert_group 'nogroup'
+  pem_cert_group key_group
   pem_cert_mode '0707'
 end

--- a/test/integration/client-el6/serverspec/certificates_spec.rb
+++ b/test/integration/client-el6/serverspec/certificates_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+require 'socket'
+
+
+# TODO: Make this a bit more DRY
+
+hostname = Socket.gethostname
+fqdn = Socket.gethostbyname(Socket.gethostname).first
+
+describe 'testcert-simple' do
+  key = '/tmp/testcert-simple.key'
+  cert = '/tmp/testcert-simple.crt'
+
+  it 'should have a valid private key' do
+    expect(x509_private_key(key)).to be_valid
+  end
+
+  it 'key is owned by root' do
+    expect(file(key)).to be_owned_by 'root'
+  end
+
+  it 'key is grouped into root' do
+    expect(file(key)).to be_grouped_into 'root'
+  end
+
+  it 'key is mode 600' do
+    expect(file(key)).to be_mode '600'
+  end
+
+  it 'should have a certificate' do
+    expect(x509_certificate(cert)).to be_certificate
+  end
+
+  it 'certificate is owned by root' do
+    expect(file(cert)).to be_owned_by 'root'
+  end
+
+  it 'certificate is grouped into root' do
+    expect(file(cert)).to be_grouped_into 'root'
+  end
+
+  it 'cert is mode 600' do
+    expect(file(cert)).to be_mode '600'
+  end
+
+  it 'key and certificate should match' do
+    expect(x509_private_key(key)).to have_matching_certificate(cert)
+  end
+
+  it 'should be valid' do
+    expect(x509_certificate(cert)).to be_valid
+  end
+
+  it "should have the subject /O=IPA.EXAMPLE.COM/CN=#{hostname}" do
+    expect(x509_certificate(cert).subject).to match "/O=IPA.EXAMPLE.COM/CN=#{hostname}"
+  end
+end
+
+describe 'testcert-fqdn' do
+  key = '/tmp/testcert-fqdn.key'
+  cert = '/tmp/testcert-fqdn.crt'
+
+  it 'should have a valid private key' do
+    expect(x509_private_key(key)).to be_valid
+  end
+
+  it 'should have a certificate' do
+    expect(x509_certificate(cert)).to be_certificate
+  end
+
+  it 'key and certificate should match' do
+    expect(x509_private_key(key)).to have_matching_certificate(cert)
+  end
+
+  it 'should be valid' do
+    expect(x509_certificate(cert)).to be_valid
+  end
+
+  it "should have the subject /O=IPA.EXAMPLE.COM/CN=#{fqdn}" do
+    expect(x509_certificate(cert).subject).to match "/O=IPA.EXAMPLE.COM/CN=#{fqdn}"
+  end
+end
+
+describe 'testcert-owner-test' do
+  key = '/tmp/testcert-owner-test.key'
+  cert = '/tmp/testcert-owner-test.crt'
+
+  it 'should have a valid private key' do
+    expect(x509_private_key(key)).to be_valid
+  end
+
+  it 'key is owned by nobody' do
+    expect(file(key)).to be_owned_by 'nobody'
+  end
+
+  it 'key is grouped into nobody' do
+    expect(file(key)).to be_grouped_into 'nobody'
+  end
+
+  it 'key is mode 707' do
+    expect(file(key)).to be_mode '707'
+  end
+
+  it 'should have a certificate' do
+    expect(x509_certificate(cert)).to be_certificate
+  end
+
+  it 'certificate is owned by nobody' do
+    expect(file(cert)).to be_owned_by 'nobody'
+  end
+
+  it 'certificate is grouped into nobody' do
+    expect(file(cert)).to be_grouped_into 'nobody'
+  end
+
+  it 'certificate is mode 707' do
+    expect(file(cert)).to be_mode '707'
+  end
+
+  it 'key and certificate should match' do
+    expect(x509_private_key(key)).to have_matching_certificate(cert)
+  end
+
+  it 'should be valid' do
+    expect(x509_certificate(cert)).to be_valid
+  end
+
+  it "should have the subject /O=IPA.EXAMPLE.COM/CN=#{hostname}" do
+    expect(x509_certificate(cert).subject).to match "/O=IPA.EXAMPLE.COM/CN=#{hostname}"
+  end
+end
+

--- a/test/integration/client-el6/serverspec/realm_membership_spec.rb
+++ b/test/integration/client-el6/serverspec/realm_membership_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'IPA realm IPA.EXAMPLE.COM' do
+
+  it 'has created a user named admin' do
+    expect(user('admin')).to exist
+  end
+
+  it 'has created a group named admins' do
+    expect(group('admins')).to exist
+  end
+
+  it 'can obtain a tgt for admin@IPA.EXAMPLE.COM' do
+    expect(command('echo InsecureAdministratorPassword | kinit admin').exit_status).to equal(0)
+  end
+
+end

--- a/test/integration/client-el7/serverspec/certificates_spec.rb
+++ b/test/integration/client-el7/serverspec/certificates_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+require 'socket'
+
+
+# TODO: Make this a bit more DRY
+
+hostname = Socket.gethostname
+fqdn = Socket.gethostbyname(Socket.gethostname).first
+
+describe 'testcert-simple' do
+  key = '/tmp/testcert-simple.key'
+  cert = '/tmp/testcert-simple.crt'
+
+  it 'should have a valid private key' do
+    expect(x509_private_key(key)).to be_valid
+  end
+
+  it 'key is owned by root' do
+    expect(file(key)).to be_owned_by 'root'
+  end
+
+  it 'key is grouped into root' do
+    expect(file(key)).to be_grouped_into 'root'
+  end
+
+  it 'key is mode 600' do
+    expect(file(key)).to be_mode '600'
+  end
+
+  it 'should have a certificate' do
+    expect(x509_certificate(cert)).to be_certificate
+  end
+
+  it 'certificate is owned by root' do
+    expect(file(cert)).to be_owned_by 'root'
+  end
+
+  it 'certificate is grouped into root' do
+    expect(file(cert)).to be_grouped_into 'root'
+  end
+
+  it 'cert is mode 600' do
+    expect(file(cert)).to be_mode '600'
+  end
+
+  it 'key and certificate should match' do
+    expect(x509_private_key(key)).to have_matching_certificate(cert)
+  end
+
+  it 'should be valid' do
+    expect(x509_certificate(cert)).to be_valid
+  end
+
+  it "should have the subject /O=IPA.EXAMPLE.COM/CN=#{hostname}" do
+    expect(x509_certificate(cert).subject).to match "/O=IPA.EXAMPLE.COM/CN=#{hostname}"
+  end
+end
+
+describe 'testcert-fqdn' do
+  key = '/tmp/testcert-fqdn.key'
+  cert = '/tmp/testcert-fqdn.crt'
+
+  it 'should have a valid private key' do
+    expect(x509_private_key(key)).to be_valid
+  end
+
+  it 'should have a certificate' do
+    expect(x509_certificate(cert)).to be_certificate
+  end
+
+  it 'key and certificate should match' do
+    expect(x509_private_key(key)).to have_matching_certificate(cert)
+  end
+
+  it 'should be valid' do
+    expect(x509_certificate(cert)).to be_valid
+  end
+
+  it "should have the subject /O=IPA.EXAMPLE.COM/CN=#{fqdn}" do
+    expect(x509_certificate(cert).subject).to match "/O=IPA.EXAMPLE.COM/CN=#{fqdn}"
+  end
+end
+
+describe 'testcert-owner-test' do
+  key = '/tmp/testcert-owner-test.key'
+  cert = '/tmp/testcert-owner-test.crt'
+
+  it 'should have a valid private key' do
+    expect(x509_private_key(key)).to be_valid
+  end
+
+  it 'key is owned by nobody' do
+    expect(file(key)).to be_owned_by 'nobody'
+  end
+
+  it 'key is grouped into nobody' do
+    expect(file(key)).to be_grouped_into 'nobody'
+  end
+
+  it 'key is mode 707' do
+    expect(file(key)).to be_mode '707'
+  end
+
+  it 'should have a certificate' do
+    expect(x509_certificate(cert)).to be_certificate
+  end
+
+  it 'certificate is owned by nobody' do
+    expect(file(cert)).to be_owned_by 'nobody'
+  end
+
+  it 'certificate is grouped into nobody' do
+    expect(file(cert)).to be_grouped_into 'nobody'
+  end
+
+  it 'certificate is mode 707' do
+    expect(file(cert)).to be_mode '707'
+  end
+
+  it 'key and certificate should match' do
+    expect(x509_private_key(key)).to have_matching_certificate(cert)
+  end
+
+  it 'should be valid' do
+    expect(x509_certificate(cert)).to be_valid
+  end
+
+  it "should have the subject /O=IPA.EXAMPLE.COM/CN=#{hostname}" do
+    expect(x509_certificate(cert).subject).to match "/O=IPA.EXAMPLE.COM/CN=#{hostname}"
+  end
+end
+

--- a/test/integration/client-el7/serverspec/realm_membership_spec.rb
+++ b/test/integration/client-el7/serverspec/realm_membership_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'IPA realm IPA.EXAMPLE.COM' do
+
+  it 'has created a user named admin' do
+    expect(user('admin')).to exist
+  end
+
+  it 'has created a group named admins' do
+    expect(group('admins')).to exist
+  end
+
+  it 'can obtain a tgt for admin@IPA.EXAMPLE.COM' do
+    expect(command('echo InsecureAdministratorPassword | kinit admin').exit_status).to equal(0)
+  end
+
+end


### PR DESCRIPTION
- Added kitchen suites for centos-6 and centos-7 platforms to test the client cookbook.
- Added serverspec configurations (same tests for ubuntu clients, just copied for centos)
- Modified the request-test-certs.rb helper recipe to check for platform because RHEL users 'nobody' instead of 'nogroup' for a null group.